### PR TITLE
Module-level functions

### DIFF
--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -41,7 +41,7 @@ Here's some code to break down the wall of text a bit. A slightly complicated he
 
 Hello.hx
 ```haxe
-inline var USAGE = "Usage: hello <name> [times]";
+inline var USAGE = "Usage: hello <name> <times>";
 
 typedef Config = {
     name:String,

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -62,6 +62,8 @@ function main() {
 }
 ```
 
+As you can see, mixing module-level functions and vars with other type declarations (`typedef Config` here) works just fine.
+
 ### Reflection
 
 Since the module-level functions/vars end up being static class fields, the usual reflection should automatically work (e.g. `Reflect.field(Type.resolveClass("MyModule"), "myMethod")`). Actually I'm not sure if this is specified to work currently in Haxe, but if it does, generators should respect that and don't over-optimize `KModuleStatics` generation when reflection features are enabled.

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -68,9 +68,16 @@ As you can see, mixing module-level functions and vars with other type declarati
 
 Since the module-level functions/vars end up being static class fields, the usual reflection should automatically work (e.g. `Reflect.field(Type.resolveClass("MyModule"), "myMethod")`). Actually I'm not sure if this is specified to work currently in Haxe, but if it does, generators should respect that and don't over-optimize `KModuleStatics` generation when reflection features are enabled.
 
-## Macros, static extensions and so on
+### Macros, static extensions and so on
 
 Since, again, module-level functions/vars are actually static fields, usual rules for `using` and `@:build(MyModule.myMethod)` calls apply, nothing new here.
+
+### Final note
+
+Because this document proposes implementing module-level functions in form of static class fields,
+one may think that it would be inconsistent to have them public and imported implicitly with the module, remember however that this proposal is not about providing syntax sugar for static fields, but about defining functions and var on module level, and the fact they become static fields is an _implementation detail_.
+
+Accessibility and resolution should follow those of other module-level declarations, that is: a module-level declaration (e.g. class/typedef/etc) is public unless specified as private, all module-level declarations are imported when the module is imported. Following these rules it makes sense to have module-levels functions to be public and be imported by default.
 
 ## Impact on existing code
 

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -88,7 +88,12 @@ I don't see any viable alternatives that would allow defining plain functions. H
 
 ## Opening possibilities
 
-I think we could also use module-level functions to define extern functions (e.g. `extern function SDL_Init(flags:UInt32):Int`), but that's gonna require some more thought, because it would mean that the implicitly created class must be made extern automatically.
+I think we could also use module-level functions to define extern functions, e.g.
+```haxe
+extern function SDL_Init(flags:UInt32):Int;
+````
+
+But that's gonna require some more thought, because it would mean that the implicitly created class must be made extern automatically.
 
 ## Unresolved questions
 

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -41,25 +41,24 @@ Here's some code to break down the wall of text a bit. A slightly complicated he
 
 Hello.hx
 ```haxe
-inline var USAGE = "<name> [times]";
+inline var USAGE = "Usage: hello <name> [times]";
 
-function sayHello(name) trace('Hi, $name!');
+typedef Config = {
+    name:String,
+    times:Int,
+}
+
+function sayHello(config:Config) {
+    for (i in 0...config.times)
+        trace('Hi, ${config.name}!');
+}
 
 function main() {
-    var name, times;
-    switch Sys.args() {
-        case [n]:
-            name = n;
-            times = 1;
-        case [n,t]:
-            name = n;
-            times = Std.parseInt(t);
-        default:
-            trace(USAGE);
-            return;
-    }
-    for (_ in 0...times)
-        sayHello(name);
+    var args = Sys.args();
+    if (args.length != 2)
+        trace(USAGE);
+    else
+        sayHello({name: args[0], times: Std.parseInt(args[1])});
 }
 ```
 

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -39,10 +39,10 @@ We have two options to deal with this:
 
  1) Implicitly create primary module class for module level functions and forbid explicit primary module class in this case. This would be the safest and most minimal change.
  2) Allow both primary module class and module statics class and apply additional identifier resolution rules:
-   * `import MyModule` imports both types and module-level functions from `MyModule` to local namespace.
-   * `import MyModule.method` if there's a module-level `method` function - import it, otherwise look for `method` in the primary class statics as it's done now.
-   * `import MyModule.*` imports both module-level functions and primary class statics, module-levels taking precedence.
-   * `MyModule.method()` calls the module-level function, if found, otherwise calls static method of the primary class.
+    * `import MyModule` imports both types and module-level functions from `MyModule` to local namespace.
+    * `import MyModule.method` if there's a module-level `method` function - import it, otherwise look for `method` in the primary class statics as it's done now.
+    * `import MyModule.*` imports both module-level functions and primary class statics, module-levels taking precedence.
+    * `MyModule.method()` calls the module-level function, if found, otherwise calls static method of the primary class.
 
 I propose going with the first option at least for now, because that would greatly simplify implementation and won't introduce new resolution semantics. Moreover, I think it'll be what people actually want when using module-level function declarations.
 

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -11,7 +11,7 @@ Support defining functions directly in the module (.hx file) instead  of creatin
 
 Classes are the heart of object-oriented programming found in languages like Java. In this paradigm, we model our program as interaction between class instances, so it makes sense to have classes as containers for everything. Non-factory static methods are relatively rare, so there's no practical need for functions defined outside of a class.
 
-Nowadays, however, other programming paradigms, such as functional programming is becoming more and more popular, reducing the need for classic OOP classes and instead focusing on functions that process passive data structures.
+Nowadays, however, other programming paradigms, such as functional programming are becoming more and more popular, reducing the need for classic OOP classes and instead focusing on functions that process passive data structures.
 
 Haxe provides a lot of features supporting functional oriented paradigms (most importantly first-class functions), however it lacks a clean way to actually define functions without creating a wrapping class. This is annoying and gives a feeling of bloatedness to new people coming from non-OOP background. This is particularly unfortunate, because most of our target languages support plain functions, so having to wrap everything in a class can be a con when deciding whether to use Haxe or a target language directly.
 

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -1,11 +1,11 @@
-# Module-level functions
+# Module-level functions and variables
 
 * Proposal: [HXP-NNNN](NNNN-module-level-funcs.md)
 * Author: [Dan Korostelev](https://github.com/nadako)
 
 ## Introduction
 
-Support defining functions directly in the module (.hx file) instead of creating a class with static methods.
+Support defining `function`s and `var`s directly in the module (.hx file) instead of creating a class with static fields.
 
 ## Motivation
 
@@ -21,34 +21,23 @@ Supporting module-level functions should be pretty-straightforward. To minimize 
 
  * add `TDFunction(name:String, fun:Function)` case to the `TypeDefKind` enum.
  * allow parsing functions at the module level and parse them into that `TDFunction`.
- * on module loading, when processing syntax declarations into module types, treat all module-level functions as static methods of an
-   implicitly created class. For this class we introduce a new `ClassKind` variant: `KModuleStatics` or
-   something. This is very similar to how `KAbstractImpl`-classes are implicitly created for abstract types.
+ * on module loading, when processing syntax declarations into module types, treat all module-level functions as `public static` methods of an implicitly created class. For this class we introduce a new `ClassKind` variant: `KModuleStatics` or something. This is very similar to how `KAbstractImpl`-classes are implicitly created for abstract types.
  * thereafter, when resolving an identifier (see more below), actually generate a static field access (`TTypeExpr(ModuleStatics).static(name)`).
- * when generating output, if target supports declaring plain functions (JavaScript, Lua, C++, etc.), a generator can decide to lose the `KModuleStatics` class and generate functions directly. If target requires a wrapping class (Java, C#) - generate like a normal class (plus, some optimizations an be applied, e.g. C# could mark class as `static`, and don't generate reflection helpers).
+ * when generating output, if target supports declaring plain functions (JavaScript, Lua, C++, etc.), a generator can decide to lose the wrapping `KModuleStatics` class and generate functions directly. If target requires a wrapping class (Java, C#) - generate like a normal class (plus, some optimizations an be applied, e.g. C# could mark class as `static`, and don't generate reflection helpers).
 
-> While this proposal describes module-level functions, I think it would be logical and consistent (although less useful) to also allow module-level variables, treating them similarly static vars.
+While the default access modifier for module-level functions is `public`, private module-level functions are supported by explicitly specifying the `private` keyword.
 
-The `-main` argument should also handle module-level functions for program entry points.
+While this proposal describes module-level functions, vars are implemented the same with a `TDVar` variant. Properties can be supported too.
 
 ### Identifier resolution
 
-The idea of module-level identifiers doesn't play particularly well with our current static field resolution mechanism, mainly because we already have the concept of "primary module class" (a class with the same name as the module), so we have to think about the sane resolution rules.
+The idea of module-level identifiers doesn't play particularly well with our current static field resolution mechanism, because we already have the concept of "primary module class" (a class with the same name as the module), so the most logical and least intrusive way to implement this would be to simply collect module-level functions in a implicitly created primary class and forbid explicit primary class declaration when there are module-level functions or vars.
 
-We have two options to deal with this:
-
- 1) Implicitly create primary module class for module-level functions and forbid explicit primary module class in this case. This would be the safest and most minimal change.
- 2) Allow both primary module class and module statics class and apply additional identifier resolution rules:
-    * `import MyModule` imports both types and module-level functions from `MyModule` to local namespace.
-    * `import MyModule.method` if there's a module-level `method` function - import it, otherwise look for `method` in the primary class statics as it's done now.
-    * `import MyModule.*` imports both module-level functions and primary class statics, module-levels taking precedence.
-    * `MyModule.method()` calls the module-level function, if found, otherwise calls static method of the primary class.
-
-I propose going for the first option at least for now, because that would greatly simplify implementation and won't introduce new resolution semantics. Moreover, I think it'll be what people actually want when using module-level function declarations.
+Importing a module with `KModuleStatics` primary class should also imply `import ModuleName.*`, which means that all module-level functions/vars are imported by importing the module, which I believe would be the expected behaviour.
 
 ### Code example
 
-Here's some code to break down the wall of test a bit (also including module-level variables for the sake of example):
+Here's some code to break down the wall of text a bit. A slightly complicated hello-world command line script would look something like this:
 
 Hello.hx
 ```haxe
@@ -74,6 +63,14 @@ function main() {
 }
 ```
 
+### Reflection
+
+Since the module-level functions/vars end up being static class fields, the usual reflection should automatically work (e.g. `Reflect.field(Type.resolveClass("MyModule"), "myMethod")`). Actually I'm not sure if this is specified to work currently in Haxe, but if it does, generators should respect that and don't over-optimize `KModuleStatics` generation when reflection features are enabled.
+
+## Macros, static extensions and so on
+
+Since, again, module-level functions/vars are actually static fields, usual rules for `using` and `@:build(MyModule.myMethod)` calls apply, nothing new here.
+
 ## Impact on existing code
 
 With regard to existing code, this change can only potentially affect macro code because of newly introduced enum constructors in the macro API, and I believe that a very small portion of macro code will be affected by this, because it only matters for exhaustive pattern matches on `TypeDefKind` and `ClassKind` which are quite rare.
@@ -97,5 +94,4 @@ But that's gonna require some more thought, because it would mean that the impli
 
 ## Unresolved questions
 
- * importing/identifier resolution - two variants proposed.
- * module-level vars - generally considered bad style, but would be consistent to have and can actually be useful for small scripts
+None so far.

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -1,0 +1,81 @@
+# Module-level functions and variables
+
+* Proposal: [HXP-NNNN](NNNN-module-level-funcs.md)
+* Author: [Dan Korostelev](https://github.com/nadako)
+
+## Introduction
+
+Support defining functions directly in the module (.hx file) instead
+of creating a class with static methods.
+
+## Motivation
+
+Classes are the heart of object-oriented programming found in languages like Java. In this paradigm, we
+model our program as interaction between class instances, so it makes sense to have classes as containers
+for everything. Non-factory static methods are relatively rare, so there's no need for functions defined outside of a class.
+
+Nowadays, however, other programming paradigms, such as functional programming is becoming more and more
+popular, reducing the need for classic OOP classes and instead focusing on functions that process passive
+data structures.
+
+Haxe provides a lot of features supporting functional oriented paradigms (most importantly first-class functions),
+however it lacks a clean way to actually define functions without creating a wrapping class. This is annoying and
+gives a feeling of bloatedness to new people coming from non-OOP background. This is particularly unfortunate,
+because most of our target languages support plain functions, so having to wrap everything in a
+class can be a con when deciding whether to use Haxe or a target language directly.
+
+## Detailed design
+
+Supporting module-level functions should be pretty-straightforward. To minimize changes in compiler and its data
+structures, as well as the macro API, I propose the following:
+
+ * add `TDFunction(name:String, fun:Function)` case to the `TypeDefKind` enum;
+ * allow parsing functions at the module level and parse them into that `TDFunction`;
+ * when processind syntax into typed AST, treat all module-level functions as static methods of an
+   implicitly created class. For this class we introduce a new `ClassKind` variant: `KModuleStatics` or
+   something. This is very similar to how `KAbstractImpl`-classes are implicitly created for abstract types.
+ * thereafter, when resolving an identifier (see more below), actually generate a static field access (`TTypeExpr(ModuleStatics).static(name)`)
+ * when generating output, if target supports declaring plain functions (JavaScript, Lua, C, etc.), a generator
+   can decide to lose the `KModuleStatics` class and generate functions directly. If target requires a wrapping
+   class (Java, C#), generate like a normal class (plus, some optimizations an be applied, e.g. C# could mark
+   class as `static`, and don't generate reflection helpers).
+
+While this proposal describes module-level functions, I think it would be logical and consistent (although less useful) to also allow module-level variables, treating them similarly static vars.
+
+The `-main` argument should also handle module-level functions for program entry points.
+
+### Identifier resolution
+
+The idea of module-level identifiers doesn't play particularly well with our current static field resolution mechanism, mainly because we already have the concept of "primary module class", so we have to think about the sane resolution rules. Here's what I propose:
+
+ * `import MyModule` imports both types and module-level functions from `MyModule` to local namespace.
+ * `import MyModule.method` if there's a module-level `method` function - import it, otherwise look for `method` in the primary class statics as it's done now.
+ * `import MyModule.*` imports both module-level functions and primary class statics, module-levels taking precedence.
+
+fully-qualified paths are resolved accordingly:
+
+ * `MyModule.method()` calls the module-level function, if found, otherwise calls static method of the primary class.
+
+> TODO: Maybe we should just forbid having explicit primary type if there are module-level functions and generate
+it implicitly. This should cover most use-cases and greatly simplify resolution rules (basically, no changes to it will be required at all).
+
+## Impact on existing code
+
+> TODO: only macro data structures, not changed but added, might only break exhaustive pattern matches.
+
+## Drawbacks
+
+> TODO: Describe the drawbacks of the proposed design worth consideration. This doesn't include breaking changes, since that's described in the previous section.
+
+## Alternatives
+
+> TODO: What alternatives have you considered to address the same problem, why the proposed solution is better?
+
+## Opening possibilities
+
+> TODO: Does this change make other future changes possible or easier? Leave this section out if the proposed change
+is completely self-contained.
+
+## Unresolved questions
+
+> TODO: Which parts of the design in question is still to be determined?

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -5,29 +5,19 @@
 
 ## Introduction
 
-Support defining functions directly in the module (.hx file) instead
-of creating a class with static methods.
+Support defining functions directly in the module (.hx file) instead  of creating a class with static methods.
 
 ## Motivation
 
-Classes are the heart of object-oriented programming found in languages like Java. In this paradigm, we
-model our program as interaction between class instances, so it makes sense to have classes as containers
-for everything. Non-factory static methods are relatively rare, so there's no practical need for functions defined outside of a class.
+Classes are the heart of object-oriented programming found in languages like Java. In this paradigm, we model our program as interaction between class instances, so it makes sense to have classes as containers for everything. Non-factory static methods are relatively rare, so there's no practical need for functions defined outside of a class.
 
-Nowadays, however, other programming paradigms, such as functional programming is becoming more and more
-popular, reducing the need for classic OOP classes and instead focusing on functions that process passive
-data structures.
+Nowadays, however, other programming paradigms, such as functional programming is becoming more and more popular, reducing the need for classic OOP classes and instead focusing on functions that process passive data structures.
 
-Haxe provides a lot of features supporting functional oriented paradigms (most importantly first-class functions),
-however it lacks a clean way to actually define functions without creating a wrapping class. This is annoying and
-gives a feeling of bloatedness to new people coming from non-OOP background. This is particularly unfortunate,
-because most of our target languages support plain functions, so having to wrap everything in a
-class can be a con when deciding whether to use Haxe or a target language directly.
+Haxe provides a lot of features supporting functional oriented paradigms (most importantly first-class functions), however it lacks a clean way to actually define functions without creating a wrapping class. This is annoying and gives a feeling of bloatedness to new people coming from non-OOP background. This is particularly unfortunate, because most of our target languages support plain functions, so having to wrap everything in a class can be a con when deciding whether to use Haxe or a target language directly.
 
 ## Detailed design
 
-Supporting module-level functions should be pretty-straightforward. To minimize changes in compiler and its data
-structures, as well as the macro API, I propose the following:
+Supporting module-level functions should be pretty-straightforward. To minimize changes in compiler and its data structures, as well as the macro API, I propose the following:
 
  * add `TDFunction(name:String, fun:Function)` case to the `TypeDefKind` enum;
  * allow parsing functions at the module level and parse them into that `TDFunction`;
@@ -35,10 +25,7 @@ structures, as well as the macro API, I propose the following:
    implicitly created class. For this class we introduce a new `ClassKind` variant: `KModuleStatics` or
    something. This is very similar to how `KAbstractImpl`-classes are implicitly created for abstract types.
  * thereafter, when resolving an identifier (see more below), actually generate a static field access (`TTypeExpr(ModuleStatics).static(name)`)
- * when generating output, if target supports declaring plain functions (JavaScript, Lua, C, etc.), a generator
-   can decide to lose the `KModuleStatics` class and generate functions directly. If target requires a wrapping
-   class (Java, C#), generate like a normal class (plus, some optimizations an be applied, e.g. C# could mark
-   class as `static`, and don't generate reflection helpers).
+ * when generating output, if target supports declaring plain functions (JavaScript, Lua, C, etc.), a generator can decide to lose the `KModuleStatics` class and generate functions directly. If target requires a wrapping class (Java, C#), generate like a normal class (plus, some optimizations an be applied, e.g. C# could mark class as `static`, and don't generate reflection helpers).
 
 While this proposal describes module-level functions, I think it would be logical and consistent (although less useful) to also allow module-level variables, treating them similarly static vars.
 
@@ -46,22 +33,23 @@ The `-main` argument should also handle module-level functions for program entry
 
 ### Identifier resolution
 
-The idea of module-level identifiers doesn't play particularly well with our current static field resolution mechanism, mainly because we already have the concept of "primary module class", so we have to think about the sane resolution rules. Here's what I propose:
+The idea of module-level identifiers doesn't play particularly well with our current static field resolution mechanism, mainly because we already have the concept of "primary module class" (a class with the same name as the module), so we have to think about the sane resolution rules.
 
- * `import MyModule` imports both types and module-level functions from `MyModule` to local namespace.
- * `import MyModule.method` if there's a module-level `method` function - import it, otherwise look for `method` in the primary class statics as it's done now.
- * `import MyModule.*` imports both module-level functions and primary class statics, module-levels taking precedence.
+We have two options to deal with this:
 
-fully-qualified paths are resolved accordingly:
+ 1) Implicitly create primary module class for module level functions and forbid explicit primary module class in this case. This would be the safest and most minimal change.
+ 2) Allow both primary module class and module statics class and apply additional identifier resolution rules:
+   * `import MyModule` imports both types and module-level functions from `MyModule` to local namespace.
+   * `import MyModule.method` if there's a module-level `method` function - import it, otherwise look for `method` in the primary class statics as it's done now.
+   * `import MyModule.*` imports both module-level functions and primary class statics, module-levels taking precedence.
+   * `MyModule.method()` calls the module-level function, if found, otherwise calls static method of the primary class.
 
- * `MyModule.method()` calls the module-level function, if found, otherwise calls static method of the primary class.
-
-> TODO: Maybe we should just forbid having explicit primary type if there are module-level functions and generate
-it implicitly. This should cover most use-cases and greatly simplify resolution rules (basically, no changes to it will be required at all).
+I propose going with the first option at least for now, because that would greatly simplify implementation and won't introduce new resolution semantics. Moreover, I think it'll be what people actually want when using module-level function declarations.
 
 ## Impact on existing code
 
-> TODO: only macro data structures, not changed but added, might only break exhaustive pattern matches.
+With regard to existing code, this change can only potentially affect macro code because of newly introduced enum constructors in the macro API, and I believe that a very small portion of macro
+code will be affected by this, because it only matters for exhaustive pattern matches on `TypeDefKind` and `ClassKind` which are quite rare.
 
 ## Drawbacks
 

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -46,6 +46,34 @@ We have two options to deal with this:
 
 I propose going for the first option at least for now, because that would greatly simplify implementation and won't introduce new resolution semantics. Moreover, I think it'll be what people actually want when using module-level function declarations.
 
+### Code example
+
+Here's some code to break down the wall of test a bit (also including module-level variables for the sake of example):
+
+Hello.hx
+```haxe
+inline var USAGE = "<name> [times]";
+
+function sayHello(name) trace('Hi, $name!');
+
+function main() {
+    var name, times;
+    switch Sys.args() {
+        case [n]:
+            name = n;
+            times = 1;
+        case [n,t]:
+            name = n;
+            times = Std.parseInt(t);
+        default:
+            trace(USAGE);
+            return;
+    }
+    for (_ in 0...times)
+        sayHello(name);
+}
+```
+
 ## Impact on existing code
 
 With regard to existing code, this change can only potentially affect macro code because of newly introduced enum constructors in the macro API, and I believe that a very small portion of macro code will be affected by this, because it only matters for exhaustive pattern matches on `TypeDefKind` and `ClassKind` which are quite rare.
@@ -57,6 +85,10 @@ I don't immediately see any drawbacks in the proposed feature. On the contrary, 
 ## Alternatives
 
 I don't see any viable alternatives that would allow defining plain functions. Having a Haxe superset that is compiled to Haxe with a macro or in any other way isn't something anyone would seriously consider in practice.
+
+## Opening possibilities
+
+I think we could also use module-level functions to define extern functions (e.g. `extern function SDL_Init(flags:UInt32):Int`), but that's gonna require some more thought, because it would mean that the implicitly created class must be made extern automatically.
 
 ## Unresolved questions
 

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -5,13 +5,13 @@
 
 ## Introduction
 
-Support defining functions directly in the module (.hx file) instead  of creating a class with static methods.
+Support defining functions directly in the module (.hx file) instead of creating a class with static methods.
 
 ## Motivation
 
 Classes are the heart of object-oriented programming found in languages like Java. In this paradigm, we model our program as interaction between class instances, so it makes sense to have classes as containers for everything. Non-factory static methods are relatively rare, so there's no practical need for functions defined outside of a class.
 
-Nowadays, however, other programming paradigms, such as functional programming are becoming more and more popular, reducing the need for classic OOP classes and instead focusing on functions that process passive data structures.
+Nowadays, however, other programming paradigms, such as functional programming are becoming more and more popular, reducing the need for classic OOP classes and instead focusing more on functions that process passive data structures.
 
 Haxe provides a lot of features supporting functional oriented paradigms (most importantly first-class functions), however it lacks a clean way to actually define functions without creating a wrapping class. This is annoying and gives a feeling of bloatedness to new people coming from non-OOP background. This is particularly unfortunate, because most of our target languages support plain functions, so having to wrap everything in a class can be a con when deciding whether to use Haxe or a target language directly.
 
@@ -19,13 +19,13 @@ Haxe provides a lot of features supporting functional oriented paradigms (most i
 
 Supporting module-level functions should be pretty-straightforward. To minimize changes in compiler and its data structures, as well as the macro API, I propose the following:
 
- * add `TDFunction(name:String, fun:Function)` case to the `TypeDefKind` enum;
- * allow parsing functions at the module level and parse them into that `TDFunction`;
- * when processind syntax into typed AST, treat all module-level functions as static methods of an
+ * add `TDFunction(name:String, fun:Function)` case to the `TypeDefKind` enum.
+ * allow parsing functions at the module level and parse them into that `TDFunction`.
+ * on module loading, when processing syntax declarations into module types, treat all module-level functions as static methods of an
    implicitly created class. For this class we introduce a new `ClassKind` variant: `KModuleStatics` or
    something. This is very similar to how `KAbstractImpl`-classes are implicitly created for abstract types.
- * thereafter, when resolving an identifier (see more below), actually generate a static field access (`TTypeExpr(ModuleStatics).static(name)`)
- * when generating output, if target supports declaring plain functions (JavaScript, Lua, C, etc.), a generator can decide to lose the `KModuleStatics` class and generate functions directly. If target requires a wrapping class (Java, C#), generate like a normal class (plus, some optimizations an be applied, e.g. C# could mark class as `static`, and don't generate reflection helpers).
+ * thereafter, when resolving an identifier (see more below), actually generate a static field access (`TTypeExpr(ModuleStatics).static(name)`).
+ * when generating output, if target supports declaring plain functions (JavaScript, Lua, C++, etc.), a generator can decide to lose the `KModuleStatics` class and generate functions directly. If target requires a wrapping class (Java, C#) - generate like a normal class (plus, some optimizations an be applied, e.g. C# could mark class as `static`, and don't generate reflection helpers).
 
 > While this proposal describes module-level functions, I think it would be logical and consistent (although less useful) to also allow module-level variables, treating them similarly static vars.
 
@@ -37,19 +37,18 @@ The idea of module-level identifiers doesn't play particularly well with our cur
 
 We have two options to deal with this:
 
- 1) Implicitly create primary module class for module level functions and forbid explicit primary module class in this case. This would be the safest and most minimal change.
+ 1) Implicitly create primary module class for module-level functions and forbid explicit primary module class in this case. This would be the safest and most minimal change.
  2) Allow both primary module class and module statics class and apply additional identifier resolution rules:
     * `import MyModule` imports both types and module-level functions from `MyModule` to local namespace.
     * `import MyModule.method` if there's a module-level `method` function - import it, otherwise look for `method` in the primary class statics as it's done now.
     * `import MyModule.*` imports both module-level functions and primary class statics, module-levels taking precedence.
     * `MyModule.method()` calls the module-level function, if found, otherwise calls static method of the primary class.
 
-I propose going with the first option at least for now, because that would greatly simplify implementation and won't introduce new resolution semantics. Moreover, I think it'll be what people actually want when using module-level function declarations.
+I propose going for the first option at least for now, because that would greatly simplify implementation and won't introduce new resolution semantics. Moreover, I think it'll be what people actually want when using module-level function declarations.
 
 ## Impact on existing code
 
-With regard to existing code, this change can only potentially affect macro code because of newly introduced enum constructors in the macro API, and I believe that a very small portion of macro
-code will be affected by this, because it only matters for exhaustive pattern matches on `TypeDefKind` and `ClassKind` which are quite rare.
+With regard to existing code, this change can only potentially affect macro code because of newly introduced enum constructors in the macro API, and I believe that a very small portion of macro code will be affected by this, because it only matters for exhaustive pattern matches on `TypeDefKind` and `ClassKind` which are quite rare.
 
 ## Drawbacks
 

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -23,7 +23,7 @@ Supporting module-level functions should be pretty-straightforward. To minimize 
  * allow parsing functions at the module level and parse them into that `TDFunction`.
  * on module loading, when processing syntax declarations into module types, treat all module-level functions as `public static` methods of an implicitly created class. For this class we introduce a new `ClassKind` variant: `KModuleStatics` or something. This is very similar to how `KAbstractImpl`-classes are implicitly created for abstract types.
  * thereafter, when resolving an identifier (see more below), actually generate a static field access (`TTypeExpr(ModuleStatics).static(name)`).
- * when generating output, if target supports declaring plain functions (JavaScript, Lua, C++, etc.), a generator can decide to lose the wrapping `KModuleStatics` class and generate functions directly. If target requires a wrapping class (Java, C#) - generate like a normal class (plus, some optimizations an be applied, e.g. C# could mark class as `static`, and don't generate reflection helpers).
+ * when generating output, if target supports declaring plain functions (JavaScript, Lua, C++, etc.), a generator can decide to lose the wrapping `KModuleStatics` class and generate functions directly. If target requires a wrapping class (Java, C#) - generate like a normal class (plus, some optimizations can be applied, e.g. C# could mark class as `static`, and don't generate reflection helpers).
 
 While the default access modifier for module-level functions is `public`, private module-level functions are supported by explicitly specifying the `private` keyword.
 

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -1,4 +1,4 @@
-# Module-level functions and variables
+# Module-level functions
 
 * Proposal: [HXP-NNNN](NNNN-module-level-funcs.md)
 * Author: [Dan Korostelev](https://github.com/nadako)
@@ -12,7 +12,7 @@ of creating a class with static methods.
 
 Classes are the heart of object-oriented programming found in languages like Java. In this paradigm, we
 model our program as interaction between class instances, so it makes sense to have classes as containers
-for everything. Non-factory static methods are relatively rare, so there's no need for functions defined outside of a class.
+for everything. Non-factory static methods are relatively rare, so there's no practical need for functions defined outside of a class.
 
 Nowadays, however, other programming paradigms, such as functional programming is becoming more and more
 popular, reducing the need for classic OOP classes and instead focusing on functions that process passive

--- a/proposals/0000-module-level-funcs.md
+++ b/proposals/0000-module-level-funcs.md
@@ -27,7 +27,7 @@ Supporting module-level functions should be pretty-straightforward. To minimize 
  * thereafter, when resolving an identifier (see more below), actually generate a static field access (`TTypeExpr(ModuleStatics).static(name)`)
  * when generating output, if target supports declaring plain functions (JavaScript, Lua, C, etc.), a generator can decide to lose the `KModuleStatics` class and generate functions directly. If target requires a wrapping class (Java, C#), generate like a normal class (plus, some optimizations an be applied, e.g. C# could mark class as `static`, and don't generate reflection helpers).
 
-While this proposal describes module-level functions, I think it would be logical and consistent (although less useful) to also allow module-level variables, treating them similarly static vars.
+> While this proposal describes module-level functions, I think it would be logical and consistent (although less useful) to also allow module-level variables, treating them similarly static vars.
 
 The `-main` argument should also handle module-level functions for program entry points.
 
@@ -53,17 +53,13 @@ code will be affected by this, because it only matters for exhaustive pattern ma
 
 ## Drawbacks
 
-> TODO: Describe the drawbacks of the proposed design worth consideration. This doesn't include breaking changes, since that's described in the previous section.
+I don't immediately see any drawbacks in the proposed feature. On the contrary, I believe it'll make Haxe not only more competitive in terms of expressiveness in everyday use, but also easier to learn for absolute beginners in programming, because they won't have to learn the concept of a class and static methods from the start.
 
 ## Alternatives
 
-> TODO: What alternatives have you considered to address the same problem, why the proposed solution is better?
-
-## Opening possibilities
-
-> TODO: Does this change make other future changes possible or easier? Leave this section out if the proposed change
-is completely self-contained.
+I don't see any viable alternatives that would allow defining plain functions. Having a Haxe superset that is compiled to Haxe with a macro or in any other way isn't something anyone would seriously consider in practice.
 
 ## Unresolved questions
 
-> TODO: Which parts of the design in question is still to be determined?
+ * importing/identifier resolution - two variants proposed.
+ * module-level vars - generally considered bad style, but would be consistent to have and can actually be useful for small scripts


### PR DESCRIPTION
Allow defining functions (and maybe vars) directly in .hx files instead of making a class with static methods.

[Rendered version](https://github.com/nadako/haxe-evolution/blob/module_level_funcs/proposals/0000-module-level-funcs.md)