### PR TITLE
Default type parameters

### DIFF
--- a/proposals/0000-default-type-parameters.md
+++ b/proposals/0000-default-type-parameters.md
@@ -14,6 +14,8 @@ $type((null: Test)); // Test<String>
 
 ## Motivation
 
+### Use case: types
+
 Some types can benefit from having default type parameters. As an example look at
 a generic virtual dom component: 
 ````haxe
@@ -72,6 +74,19 @@ class Image extends Component<js.html.ImageElement>
 But in most other cases you can use `Component` directly without passing a specific element type.
 
 See also: https://github.com/HaxeFlixel/flixel/issues/1677
+
+### Use case: methods
+
+Methods with a generic type parameter are not always able to infer that type from the parameters (especially if that type is optional).
+
+````haxe
+function createMyClass<T = MyDefault>(?input: T): MyClass<T>
+  return new MyClass(if (input == null) new MyDefault() else input);
+
+$type(createMyClass()); // MyClass<MyDefault>
+````
+
+Outlined in more detail [here](https://github.com/HaxeFoundation/haxe-evolution/pull/50#issuecomment-413976704)
 
 ## Detailed design
 

--- a/proposals/0000-default-type-parameters.md
+++ b/proposals/0000-default-type-parameters.md
@@ -15,10 +15,15 @@ $type((null: Test)); // Test<String>
 ## Motivation
 
 Some types can benefit from having default type parameters. As an example look at
-a generic virtual dom component: `class Component<Props: {}, State: {}>` 
+a generic virtual dom component: 
+````haxe
+class Component<Props: {}, State: {}> {}
+````
 Users of the library subclass the Component. Often there's no state or props used,
 but with current haxe it's required to write out the empty parameters explicitly:
-`class MyComponent extends Component<{}, {}>`
+````haxe
+class MyComponent extends Component<{}, {}> {}
+````
 With defaults it's possible to simply extend and leave the defaults to the library:
 ````haxe
 class Component<Props: {} = {}, State: {} = {}> {}
@@ -49,8 +54,8 @@ Don't see any at this time.
 ## Alternatives
 
 - It's possible to emulate with `@:genericBuild` but there's some downsides:
- - Can't use those in macros
- - Can't use the type as a type hint (`var a: MyGenericBuild;`)
+  - Can't use those in macros
+  - Can't use the type as a type hint (`var a: MyGenericBuild;`)
 
 - Parameters can be inferred on first usage, but only when constructing a type.
 

--- a/proposals/0000-default-type-parameters.md
+++ b/proposals/0000-default-type-parameters.md
@@ -1,0 +1,64 @@
+# Default type parameters
+
+* Proposal: [HXP-NNNN](NNNN-filename.md)
+* Author: [Ben Merckx](https://github.com/benmerckx)
+
+## Introduction
+
+Optionally declare a default type for generic type parameters.
+
+````Haxe
+class Test<T = String> {}
+$type((null: Test)); // Test<String>
+````
+
+## Motivation
+
+Some types can benefit from having default type parameters. As an example look at
+a generic virtual dom component: `class Component<Props: {}, State: {}>` 
+Users of the library subclass the Component. Often there's no state or props used,
+but with current haxe it's required to write out the empty parameters explicitly:
+`class MyComponent extends Component<{}, {}>`
+With defaults it's possible to simply extend and leave the defaults to the library:
+````haxe
+class Component<Props: {} = {}, State: {} = {}> {}
+class MyComponent extends Component {}
+class MyComponentWithProps extends Component<MyProps> {}
+class MyComponentWithPropsAndState extends Component<MyProps, MyState> {}
+````
+
+See also: https://github.com/HaxeFlixel/flixel/issues/1677
+
+## Detailed design
+
+- Parse the new type parameter syntax for type declarations
+- Ensure the default unifies with possible type guards
+- Disallow a type parameter with a default to be followed by one without
+- Use the default parameter when the type is used and there's none declared
+
+## Impact on existing code
+
+If the defaults are available in macro context this can break existing macros 
+that work with type parameters. Otherwise code that does not use the defaults
+should function exactly the same.
+
+## Drawbacks
+
+Don't see any at this time.
+
+## Alternatives
+
+- It's possible to emulate with `@:genericBuild` but there's some downsides:
+ - Can't use those in macros
+ - Can't use the type as a type hint (`var a: MyGenericBuild;`)
+
+- Parameters can be inferred on first usage, but only when constructing a type.
+
+- Aliases can be used to set defaults: `typedef EmptyComponent = Component<{}, {}>`
+It usually makes things more complex than necessary, see also: 
+https://github.com/massiveinteractive/haxe-react/blob/19156680859ac0e27249762101cb8533b911a141/src/lib/react/ReactComponent.hx#L14.
+
+## Unresolved questions
+
+- Should the defaults have access to the other parameters?
+  `Test<A, B, C = A & B>` This would introduce a lot of edge cases.


### PR DESCRIPTION
Follow up of haxefoundation/haxe#7304

Optionally declare a default type for generic type parameters.

````Haxe
class Test<T = String> {}
$type((null: Test)); // Test<String>
````

[Rendered version](https://github.com/benmerckx/haxe-evolution/blob/master/proposals/0000-default-type-parameters.md)