### PR TITLE
Implied Field Names on Object Literals

### DIFF
--- a/proposals/0000-implied-fieldnames.md
+++ b/proposals/0000-implied-fieldnames.md
@@ -1,0 +1,46 @@
+# ::enter feature name here::
+
+* Proposal: [HXP-NNNN](NNNN-filename.md)
+* Author: [Haxe Developer](https://github.com/haxedev)
+
+## Introduction
+
+Short description of the proposed feature. Keep it short, so the reader
+can quickly get what's it all about.
+
+## Motivation
+
+Describe the problems addressed by this feature. If a similar effect
+can be achieved without it with some workarounds, describe the drawbacks
+of the workaround. If it's something completely new, show how it will
+help developers write better Haxe code or how it will improve the generation
+of target code by the compiler.
+
+## Detailed design
+
+Describe the proposed design in details the way language user can understand
+and compiler developer can implement. Show corner cases, provide usage examples,
+describe how this solution is better than current workarounds.
+
+## Impact on existing code
+
+What impact this change will have on existing code? Will it break compilation?
+Will it compile, but break in run-time? How easy it is to migrate existing Haxe code?
+
+## Drawbacks
+
+Describe the drawbacks of the proposed design worth consideration. This doesn't include
+breaking changes, since that's described in the previous section.
+
+## Alternatives
+
+What alternatives have you considered to address the same problem, why the proposed solution is better?
+
+## Opening possibilities
+
+Does this change make other future changes possible or easier? Leave this section out if the proposed change
+is completely self-contained.
+
+## Unresolved questions
+
+Which parts of the design in question is still to be determined?

--- a/proposals/0000-implied-fieldnames.md
+++ b/proposals/0000-implied-fieldnames.md
@@ -1,4 +1,4 @@
-# ::enter feature name here::
+# Implied Field Names on Object Literals
 
 * Proposal: [HXP-NNNN](0000-implied-fieldnames.md)
 * Author: [Neil Graham](https://github.com/Lerc)
@@ -7,7 +7,9 @@
 
 Add implied field names to object literals. 
 
-essentially allow `{fish,cheese}` instead of requiring `{fish:fish,cheese:cheese}`
+If a field name and value is represented by the same text allow it to be written just once.
+
+Essentially allow `{fish,cheese}` instead of requiring `{fish:fish,cheese:cheese}`
 
 ## Motivation
 

--- a/proposals/0000-implied-fieldnames.md
+++ b/proposals/0000-implied-fieldnames.md
@@ -1,46 +1,72 @@
 # ::enter feature name here::
 
-* Proposal: [HXP-NNNN](NNNN-filename.md)
-* Author: [Haxe Developer](https://github.com/haxedev)
+* Proposal: [HXP-NNNN](0000-implied-fieldnames.md)
+* Author: [Neil Graham](https://github.com/Lerc)
 
 ## Introduction
 
-Short description of the proposed feature. Keep it short, so the reader
-can quickly get what's it all about.
+Add implied field names to object literals. 
+
+essentially allow `{fish,cheese}` instead of requiring `{fish:fish,cheese:cheese}`
 
 ## Motivation
 
-Describe the problems addressed by this feature. If a similar effect
-can be achieved without it with some workarounds, describe the drawbacks
-of the workaround. If it's something completely new, show how it will
-help developers write better Haxe code or how it will improve the generation
-of target code by the compiler.
+This allows simplification of code, making it easier to read and
+reducing the possibility of errors.
+
+It is common practice to have variables that will be placed into a
+field of an object that shares the name of the variable.  
+Allowing the simplified form is not only more concise and easier to read, but also
+highlights instances of the expanded form as being notably different.
+
+```
+var x=1.5;
+var y=3;
+var pt2 = {x, y}
+var pt3 = {x, y, z:someOtherValue}     // z stands out as a special case
+```
+
+In addition to the reasons here, It is worth noting that this feature has been 
+added to Javascript and most of the justifications for doing so also apply here
+as well as the additional aspect of easing transition between JavaScript 
+and Haxe programming.
+
+
 
 ## Detailed design
 
-Describe the proposed design in details the way language user can understand
-and compiler developer can implement. Show corner cases, provide usage examples,
-describe how this solution is better than current workarounds.
+For any object literal field definition the value may be omitted if the identifier
+specifying the field name is also a valid identifier for an in-scope value;
+
+This could also be thought of the other way around,  If an object literal value is represented by a single identifier, the field name need not be specified and will take the name of the identifier.
+
+Thus for any object that may be specified as
+```
+var example = {a:a,  b:b, c:d, e:a+b};
+```
+could also be specified as 
+```
+var example = {a,b, c:d, e:a+b};
+```
+
+This would only occur in instances where the value can be specified by a single identifier.
 
 ## Impact on existing code
 
-What impact this change will have on existing code? Will it break compilation?
-Will it compile, but break in run-time? How easy it is to migrate existing Haxe code?
+This should keep compatibility with existing code.   No changes would be required, but a
+great deal of existing code could be rendered smaller and more readable by utilizing this
+feature.  A parser could easily identify opportunities and recommend this change 
 
 ## Drawbacks
 
-Describe the drawbacks of the proposed design worth consideration. This doesn't include
-breaking changes, since that's described in the previous section.
+undiscovered.
 
 ## Alternatives
 
-What alternatives have you considered to address the same problem, why the proposed solution is better?
+The alternative is just to live without it, but that does require typing identifier:identifier a lot which always has the possibility of introducing errors by typo.
 
 ## Opening possibilities
 
-Does this change make other future changes possible or easier? Leave this section out if the proposed change
-is completely self-contained.
+Recent versions of ECMAScript have introduced a full suite of enhancements that bear looking at,  Not simply to mimic JavaScript, but because the reasoning behind those enhancements is quite sound.   
 
-## Unresolved questions
-
-Which parts of the design in question is still to be determined?
+This proposal is the simplest of those enhancements, I intent to propose more of these enhancements for discussion in future.  Should this proposal succeed I would propose looking at the destructuring assignment enhancements next;


### PR DESCRIPTION
short version:
allow
 `var myPoint ={x,y};`
 instead of 
`var myPoint ={x:x,y:y};`

[Rendered version](https://github.com/Lerc/haxe-evolution/blob/master/proposals/0000-implied-fieldnames.md)