### PR TITLE
Command to init empty Haxe project.

### DIFF
--- a/proposals/0000-init-command.md
+++ b/proposals/0000-init-command.md
@@ -1,0 +1,67 @@
+# Command for empty project initialization
+
+* Proposal: [HXP-NNNN](NNNN-init-command.md)
+* Author: [Haxe Developer](https://github.com/dmitryhryppa)
+
+## Introduction
+
+Providinga a Haxe compiler command to create an empty project in the selected folder.
+
+## Motivation
+
+It is really annoying to create folders structure, files, declare a class and hxml params to just start coding. 
+Also, you need to spend some time to setup VSCode and VSHaxe debuggers (which is an official editor, yes?).
+
+This feature also will help a lot for new developers to start.
+
+## Detailed design
+
+To create a new empty project developer will need to call init command and optionally provide at least one target as a parameter:
+
+`haxe --init cpp js hl`
+
+Then Haxe will create a bunch of files and directories:
+```
+├───.vscode
+│   ├── settings.json
+│   └── tasks.json
+├── out
+│   ├── cpp
+│   ├── hl
+│   └── js
+│       └── main.js
+├── src
+│   └── Main.hx
+├── build.cpp.hxml
+├── build.hl.hxml
+├── build.js.hxml
+├── common.hxml
+```
+
+`.vscode` with basic settings and tasks for launching and debugging (hxcpp, hl)
+
+`src` with the Main.hx module and main class.
+
+`out` with separated directories for each target
+
+`common.hxml` with general compilation parameters. 
+
+Bunch of `build.$TARGET.hxml` with compilation parameters for every target.
+
+
+
+## Impact on existing code
+
+Not impacting existing code.
+
+## Drawbacks
+
+None.
+
+## Alternatives
+
+None
+
+## Unresolved questions
+
+None.

--- a/proposals/0000-init-command.md
+++ b/proposals/0000-init-command.md
@@ -1,7 +1,7 @@
 # Command for empty project initialization
 
 * Proposal: [HXP-NNNN](NNNN-init-command.md)
-* Author: [Haxe Developer](https://github.com/dmitryhryppa)
+* Author: [Dmitry Hryppa](https://github.com/dmitryhryppa)
 
 ## Introduction
 
@@ -25,13 +25,15 @@ Then Haxe will create a bunch of files and directories:
 ├───.vscode
 │   ├── settings.json
 │   └── tasks.json
+│
 ├── out
 │   ├── cpp
 │   ├── hl
 │   └── js
-│       └── main.js
+│
 ├── src
 │   └── Main.hx
+│
 ├── build.cpp.hxml
 ├── build.hl.hxml
 ├── build.js.hxml

--- a/proposals/0000-init-command.md
+++ b/proposals/0000-init-command.md
@@ -62,7 +62,7 @@ None.
 
 ## Alternatives
 
-None
+Create VSHaxe project templates?
 
 ## Unresolved questions
 


### PR DESCRIPTION
Providinga a Haxe compiler command to create an empty project in the selected folder.
`haxe --init cpp js hl`

Which will generate something like this:
```
├───.vscode
│   ├── settings.json
│   └── tasks.json
│
├── out
│   ├── cpp
│   ├── hl
│   └── js
│
├── src
│   └── Main.hx
│
├── build.cpp.hxml
├── build.hl.hxml
├── build.js.hxml
├── common.hxml
```


[Rendered version](https://github.com/dmitryhryppa/haxe-evolution/blob/init-command/proposals/0000-init-command.md)