### PR TITLE
Replace "null" access modifier with "this"

### DIFF
--- a/proposals/0010-null-access-modifier.md
+++ b/proposals/0010-null-access-modifier.md
@@ -1,0 +1,42 @@
+# "null" access modifier vs "this"
+
+* Proposal: [HXP-NNNN](NNNN-null-access-modifier.md)
+* Author: [Dmitry Hryppa](https://github.com/haxedev)
+
+## Introduction
+
+Replace `null` access identifier with `this`.
+
+## Motivation
+
+It's a bit confusing to use `null` as a "protected" access modifier.
+`this` is much understandable and gives as a context about who can modify the current field.
+
+## Detailed design
+
+It's only about replacing a `null` keyword with `this` as a "protected" access modifier.
+
+Example:
+```haxe
+public var isDataExists(default, this):Bool;
+```
+
+## Impact on existing code
+
+It will conflict with the old codebase. But `null` may be marked as deprecated for some time before it will be fully removed from access modifiers syntax.
+
+## Drawbacks
+
+.
+
+## Alternatives
+
+.
+
+## Opening possibilities
+
+.
+
+## Unresolved questions
+
+.

--- a/proposals/0010-null-access-modifier.md
+++ b/proposals/0010-null-access-modifier.md
@@ -5,7 +5,7 @@
 
 ## Introduction
 
-Replace `null` access identifier with `this`.
+Replace `null` identifier with `this` in access modifiers syntax.
 
 ## Motivation
 
@@ -18,12 +18,12 @@ It's only about replacing a `null` keyword with `this` as a "protected" access m
 
 Example:
 ```haxe
-public var isDataExists(default, this):Bool;
+public var data(default, this):Bool;
 ```
 
 ## Impact on existing code
 
-It will conflict with the old codebase. But `null` may be marked as deprecated for some time before it will be fully removed from access modifiers syntax.
+It will conflict with the old codebase. But `null` may be marked as deprecated for some time before it will be fully removed from the access modifiers syntax.
 
 ## Drawbacks
 


### PR DESCRIPTION
It's a bit confusing to use `null` as a private access modifier.
`this` is much more understandable and gives as a context about who can modify the current field.

Example:
```haxe
public var data(default, this):Bool;
```

[Rendered version](https://github.com/dmitryhryppa/haxe-evolution/blob/feature/access-modifier-change/proposals/0010-null-access-modifier.md)

Thanks!