### PR TITLE
Multiple argument array access

### DIFF
--- a/proposals/0000-multiple-arg-array-access.md
+++ b/proposals/0000-multiple-arg-array-access.md
@@ -36,7 +36,7 @@ When using multiple array access, there could be conflicts between getting one e
   - Semantically () has not the same meaning that [].
   - Currently there is no way to overload the = operator so we can't do `a(0, 1) = "foo"`.
 - We can use a chained array access. Drawback:
-  - At runtime we need to add a lot more logic or return proxy objects to be able to use this syntax. It adds complexity and overhead to the code. 
+  - At runtime we need to add a lot more logic or return proxy objects to be able to use this syntax that adds complexity to the code. 
 
 ## Detailed design 
 **Grammar change:**

--- a/proposals/0000-multiple-arg-array-access.md
+++ b/proposals/0000-multiple-arg-array-access.md
@@ -1,0 +1,65 @@
+# Multiple arguments for array access
+
+* Proposal: HXP-NNNN
+* Author: [rikoo](https://github.com/ErikRikoo)
+
+## Introduction
+
+Introduce an extension to the array access operator in order to allow multiple parameters between []: `array["foo", 0]`.
+This only proposes a grammar and AST modification to parse it in a macro. But it doesn't concern operator overloading (for now...).
+This proposal follows my [issue](https://github.com/HaxeFoundation/haxe/issues/9339).
+
+## Motivation
+
+This feature proposes, as stated above, is to provide multi arguments array access. 
+For now, we can only have one argument and if we provide mulitple we get an error.
+Exemple:
+```haxe
+array1[0] // allowed
+array2[0, "foo"] // Get an "Expected ]" error
+```
+
+**Workarounds:**
+- We could use a function call with multiple arguments but the purpose would be less clear than the array access. 
+  If there is an assignement operator (=, +=, ...) after, it would be even less cleat at the first sight.
+- We could also use chained array access but it would be less direct to use it in macro time.
+  Moreover, it doesn't provide the same meaning:
+  Multiple Access with one argument means "one access provide some value used to get another one".
+
+
+## Detailed design
+As stated above it is just a change in the grammar to allow multiple arguments in an array access like in a function.
+I propose to add a new enum value in Expr.ExprDef:
+```haxe
+enum ExprDef {
+   ...
+   EArray(e1:Expr, e2:Expr); // We keep this one for retro compatibility
+
+   EArrayMultiple(e1:Expr, params:Array<Expr>);
+   ...
+}
+```
+Then when a `array[a, b...]` is in the code it will be put in the AST. Then we can match it during compile time.
+The different targets can then throw an exception if it is still there when they get the AST.
+Or they could also generate code that use multiple argument array access when it is allowed like in C# or python.
+
+## Impact on existing code
+
+Because it is a new Enum value added, previous macro code will still be able to parse simple array access.
+It may break if they are using the default case in a switch on the expression definition.
+
+## Drawbacks
+
+
+## Alternatives
+
+I thought about other syntax that can be parsed like multiple array access or function call that can be parsed.
+But it is less clear or more tricky to parse in a macro.
+
+## Opening possibilities
+
+With this change to grammar it opens to overload of array access with multiple argument array access.
+I think it could be a first step to that.
+
+## Unresolved questions
+

--- a/proposals/0000-multiple-arg-array-access.md
+++ b/proposals/0000-multiple-arg-array-access.md
@@ -11,40 +11,28 @@ This proposal follows my [issue](https://github.com/HaxeFoundation/haxe/issues/9
 
 ## Motivation
 
-This feature proposes, as stated above, is to provide multi arguments array access. 
+**Current state** 
+
+This feature proposes, as stated above, to provide multi arguments array access. 
 For now, we can only have one argument and if we provide mulitple we get an error.
+
 Exemple:
 ```
 array1[0] // allowed
 array2[0, "foo"] // Get an "Expected ]" error
 ```
 
-I stepped into that issue when I tried to implement a multi dimensionnal array lib that would use a syntax close to numpy element indexing.
-But we can imagine the same problem for any object that have a meaning for indexing with multiple access, for exemple a map with a pair of keys.
-After this proposal we can write without an error:
-```
-  myMacro(array[0, "foo"]);
-```
-And the macro code:
-```
-  public static macro function myMacro(e:Expr):Expr {
-    switch(e.expr) {
-      case EArrayMultiple(e1, args):
-        return generateExpr(e1, args);
-      default:
-        return null;
-    }
-  }
+**Goals**
 
-  public static function generateExpr(e:Expr):Expr {
-    // In my case, I would return a function call
-  }
-```
-With the proposed syntax we now have a more clear semantic on what we are accessing at the first sight and it improves code readability.
+- I stepped into that issue when I tried to implement a multi dimensionnal array lib that would use a syntax close to numpy element indexing.
+But we can imagine the same problem for any object that have a meaning for indexing with multiple access, for exemple a map with a pair of keys.
+
+- With the proposed syntax we now have a more clear semantic on what we are accessing at the first sight and it improves code readability.
 When using multiple array access, there could be conflicts between getting one element from the variable and then getting something from it and an access with multiple arguments.
 
 
 **Workarounds:**
+
 - We could use a function call with multiple arguments but the purpose would be less clear than the array access. 
   If there is an assignement operator (=, +=, ...) after, it would be even less cleat at the first sight.
 - We could also use chained array access but it would be less direct to use it in macro time.
@@ -54,7 +42,7 @@ When using multiple array access, there could be conflicts between getting one e
 
 ## Detailed design 
 As stated above it is just a change in the grammar to allow multiple arguments in an array access like in a function.
-I propose two changes:
+I propose two possible changes:
 - Option 1: **add a new ExprDef**
 ```
 enum ExprDef {
@@ -75,7 +63,35 @@ enum ExprDef {
 }
 ```
 
-Then when a `array[a, b...]` is in the code it will be put in the AST and it can be matched during compile time.
+Then when a `array[a, b...]` is in the code it will be put in the AST and it can be matched during compile time, like this:
+```
+  myMacro(array[0, "foo"]);
+```
+
+And the macro code:
+- For Option 1:
+```
+  public static macro function myMacro(e:Expr):Expr {
+    switch(e.expr) {
+      case EArrayMultiple(e1, args):
+        return generateExpr(e1, args);
+      default:
+        return null;
+    }
+  }
+```
+- For Option 2:
+```
+  public static macro function myMacro(e:Expr):Expr {
+    switch(e.expr) {
+      case EArray(e1, e2, args):
+        return generateExpr(e1, e2, args);
+      default:
+        return null;
+    }
+  }
+```
+
 The different targets can then throw an exception if it is still there when they get the AST.
 Or they could also generate code that use multiple argument array access when it is allowed like in C# or python.
 

--- a/proposals/0000-multiple-arg-array-access.md
+++ b/proposals/0000-multiple-arg-array-access.md
@@ -30,8 +30,6 @@ But we can imagine the same problem for any object that have a meaning for index
 - With the proposed syntax we now have a more clear semantic on what we are accessing at the first sight and it improves code readability.
 When using multiple array access, there could be conflicts between getting one element from the variable and then getting something from it and an access with multiple arguments.
 
-- By beginning with just extending the grammar and allowing it in macro, it could be extensively tested before integrating it with operator overloading. Because for now, if you want to chain array access you will need to return a new object for each access, and then access it using sqaure brackets. So it will be a good crash test for this feature, as it would be done in two separate steps.
-
 
 **Workarounds:**
 - Using a function call with multiple arguments. Drawbacks:

--- a/proposals/0000-multiple-arg-array-access.md
+++ b/proposals/0000-multiple-arg-array-access.md
@@ -14,7 +14,7 @@ This proposal follows my [issue](https://github.com/HaxeFoundation/haxe/issues/9
 This feature proposes, as stated above, is to provide multi arguments array access. 
 For now, we can only have one argument and if we provide mulitple we get an error.
 Exemple:
-```haxe
+```
 array1[0] // allowed
 array2[0, "foo"] // Get an "Expected ]" error
 ```
@@ -30,7 +30,7 @@ array2[0, "foo"] // Get an "Expected ]" error
 ## Detailed design
 As stated above it is just a change in the grammar to allow multiple arguments in an array access like in a function.
 I propose to add a new enum value in Expr.ExprDef:
-```haxe
+```
 enum ExprDef {
    ...
    EArray(e1:Expr, e2:Expr); // We keep this one for retro compatibility
@@ -39,7 +39,7 @@ enum ExprDef {
    ...
 }
 ```
-Then when a `array[a, b...]` is in the code it will be put in the AST. Then we can match it during compile time.
+Then when a `array[a, b...]` is in the code it will be put in the AST and it can be matched during compile time.
 The different targets can then throw an exception if it is still there when they get the AST.
 Or they could also generate code that use multiple argument array access when it is allowed like in C# or python.
 

--- a/proposals/0000-multiple-arg-array-access.md
+++ b/proposals/0000-multiple-arg-array-access.md
@@ -19,6 +19,31 @@ array1[0] // allowed
 array2[0, "foo"] // Get an "Expected ]" error
 ```
 
+I stepped into that issue when I tried to implement a multi dimensionnal array lib that would use a syntax close to numpy element indexing.
+But when I try to parse it with macro to add some sugar syntax I ran into complex code just to know the number of array access on a variablewhen using `array[_][_]`, we get `EArray(EArray(array, _), _)` expr.
+The current approach would be even less easy to parse if we have more nested array access.
+With this add we could directly know the size of the argument list and what is inside.
+After this proposal we can write without an error:
+```
+  myMacro(array[0, "foo"]);
+```
+And the macro code:
+```
+  public static macro function myMacro(e:Expr):Expr {
+    switch(e.expr) {
+      case EArrayMultiple(e1, args):
+        return generateExpr(e1, args);
+      default:
+        return null;
+    }
+  }
+
+  public static function generateExpr(e:Expr):Expr {
+    // In my case, I would return a function call
+  }
+```
+
+
 **Workarounds:**
 - We could use a function call with multiple arguments but the purpose would be less clear than the array access. 
   If there is an assignement operator (=, +=, ...) after, it would be even less cleat at the first sight.

--- a/proposals/0000-multiple-arg-array-access.md
+++ b/proposals/0000-multiple-arg-array-access.md
@@ -20,9 +20,7 @@ array2[0, "foo"] // Get an "Expected ]" error
 ```
 
 I stepped into that issue when I tried to implement a multi dimensionnal array lib that would use a syntax close to numpy element indexing.
-But when I try to parse it with macro to add some sugar syntax I ran into complex code just to know the number of array access on a variablewhen using `array[_][_]`, we get `EArray(EArray(array, _), _)` expr.
-The current approach would be even less easy to parse if we have more nested array access.
-With this add we could directly know the size of the argument list and what is inside.
+But we can imagine the same problem for any object that have a meaning for indexing with multiple access, for exemple a map with a pair of keys.
 After this proposal we can write without an error:
 ```
   myMacro(array[0, "foo"]);
@@ -42,6 +40,8 @@ And the macro code:
     // In my case, I would return a function call
   }
 ```
+With the proposed syntax we now have a more clear semantic on what we are accessing at the first sight and it improves code readability.
+When using multiple array access, there could be conflicts between getting one element from the variable and then getting something from it and an access with multiple arguments.
 
 
 **Workarounds:**

--- a/proposals/0000-multiple-arg-array-access.md
+++ b/proposals/0000-multiple-arg-array-access.md
@@ -30,6 +30,8 @@ But we can imagine the same problem for any object that have a meaning for index
 - With the proposed syntax we now have a more clear semantic on what we are accessing at the first sight and it improves code readability.
 When using multiple array access, there could be conflicts between getting one element from the variable and then getting something from it and an access with multiple arguments.
 
+- By beginning with just extending the grammar and allowing it in macro, it could be extensively tested before integrating it with operator overloading. Because for now, if you want to chain array access you will need to return a new object for each access, and then access it using sqaure brackets. So it will be a good crash test for this feature, as it would be done in two separate steps.
+
 
 **Workarounds:**
 

--- a/proposals/0000-multiple-arg-array-access.md
+++ b/proposals/0000-multiple-arg-array-access.md
@@ -52,9 +52,10 @@ When using multiple array access, there could be conflicts between getting one e
   Multiple Access with one argument means "one access provide some value used to get another one".
 
 
-## Detailed design
+## Detailed design 
 As stated above it is just a change in the grammar to allow multiple arguments in an array access like in a function.
-I propose to add a new enum value in Expr.ExprDef:
+I propose two changes:
+- Option 1: **add a new ExprDef**
 ```
 enum ExprDef {
    ...
@@ -64,14 +65,25 @@ enum ExprDef {
    ...
 }
 ```
+
+- Option 2: **changing EArray definition**
+```
+enum ExprDef {
+   ...
+   EArray(e1:Expr, e2:Expr, ?others:Array<Expr>);
+   ...
+}
+```
+
 Then when a `array[a, b...]` is in the code it will be put in the AST and it can be matched during compile time.
 The different targets can then throw an exception if it is still there when they get the AST.
 Or they could also generate code that use multiple argument array access when it is allowed like in C# or python.
 
 ## Impact on existing code
-
-Because it is a new Enum value added, previous macro code will still be able to parse simple array access.
-It may break if they are using the default case in a switch on the expression definition.
+- Option 1:
+Because it is a new Enum value added, previous macro code will still be able to parse simple array access. It may break if they are using the default case in a switch on the expression definition.
+- Option 2:
+Because we add an optionnal argument to the definition the previous code will still match even if there is multiple arguments. Moreover, they will not be detected in the default case.
 
 ## Drawbacks
 


### PR DESCRIPTION
Changes to the compiler to allow `array[a, b, ....]`
[Rendered Version](https://github.com/ErikRikoo/haxe-evolution/blob/multiple-arg-array-access/proposals/0000-multiple-arg-array-access.md)