### PR TITLE
From-to shortcuts

### DIFF
--- a/proposals/0000-from-to-shortucts.md
+++ b/proposals/0000-from-to-shortucts.md
@@ -1,0 +1,47 @@
+# From-to shortcut
+
+* Proposal: [HXP-NNNN](NNNN-from-to-shortcuts.md)
+* Author: [Dmitrii Maganov](https://github.com/vonagam)
+
+## Introduction
+
+New short syntax for allowing both from and to cast.  
+New syntax for referencing underlying type in a cast.
+
+## Motivation
+
+Reduced repetetion and improved readability for two really common scenarios.
+
+## Detailed design
+
+Syntax for allowing from and to cast:
+
+```haxe
+abstract Foo(Int) from to Int {}
+// equals
+abstract Foo(Int) from Int to Int {}
+```
+
+Syntax for referencing underlying type:
+
+```haxe
+abstract Foo(Int) from this {}
+// equals
+abstract Foo(Int) from Int {}
+```
+
+## Impact on existing code
+
+None.
+
+## Drawbacks
+
+Some might say that one can forget a type between `from` and `to`...
+
+## Alternatives
+
+Repetetion.
+
+## Unresolved questions
+
+Which variant to choose for from/to cast.


### PR DESCRIPTION
Syntax for allowing from and to cast:

```haxe
abstract Foo(Int) from to Int {}
// equals
abstract Foo(Int) from Int to Int {}
```

Syntax for referencing underlying type:

```haxe
abstract Foo(Int) from this {}
// equals
abstract Foo(Int) from Int {}
```

Obviously for such short named types as std `Int` it doesn't make much sense, but for long named ones and for unnamed, like structures or functions, it would make a life more pleasant.

[Render.](https://github.com/vonagam/haxe-evolution/blob/from-to-shortcuts/proposals/0000-from-to-shortucts.md)