### PR TITLE
Single pattern checks

### DIFF
--- a/proposals/0000-single-pattern-checks.md
+++ b/proposals/0000-single-pattern-checks.md
@@ -67,26 +67,25 @@ function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> 
 ### Extract pattern variables with `extract match`
 
 ```
-[$vars =] $value extract match $pattern [where $guard] [else $elseBody]
+$value extract match $pattern [where $guard] [else $elseBody]
 ```
 
-`$vars` acts as a whitelist for exposing pattern's captured variables.
-`$elseBody` throws an exception by default. 
-`$ifBody` being everything that follows in a block.
+`$elseBody` throws an exception by default and if provided must be `return`, `break`, `continue` or `throw`.
+`$ifBody` sets captured variables in current scope.
 
 ```haxe
 function getSome(option: Option<Int>): Int {
-  final int = option extract match Some(int);
+  option extract match Some(int);
   return int;
 }
 
 function getNullSome(option: Option<Int>): Null<Int> {
-  final int = option extract match Some(int) else return null;
+  option extract match Some(int) else return null;
   return int;
 }
 
 function getDivisibleSome(option: Option<Int>, divisor: Int): Int {
-  final int = option extract match Some(int) where (int % divisor == 0);
+  option extract match Some(int) where (int % divisor == 0);
   return int;
 }
 ```

--- a/proposals/0000-single-pattern-checks.md
+++ b/proposals/0000-single-pattern-checks.md
@@ -5,104 +5,16 @@
 
 ## Introduction
 
-New syntax for single pattern checks.
+Proposal to rename `.match` single pattern check to `.case`.
 
 ## Motivation
 
-Current single pattern check - `match` method on an enum value - is limited in functionality compared to usual pattern matching. No captures or guards and only a single enum value as a root value.
-
-Proposed syntax will allow to use full arsenal of the matcher.
+To support usage on any type, not only on enum values.
 
 ## Detailed design
 
-### Test a pattern
-
-Get a boolean result with:
-
 ```haxe
-$value is case $pattern
-
-// same as
-
-switch ($value) {case $pattern: true; case _: false;}
+value.case(pattern) // returns a boolean
 ```
 
-Usage:
-
-```haxe
-function isSome(option: Option<Int>): Bool {
-  return option is case Some(_);
-}
-
-function isDivisibleSome(option: Option<Int>, divisor: Int): Bool {
-  return option is case Some(int).where(int % divisor == 0);
-}
-```
-
-### Use captured variables in a conditional body
-
-If an `if` or `while` condition is a single `is case` expression, then it is transformed like this:
-
-```haxe
-if ($value is case $pattern) {
-  // access pattern variables
-}
-
-// same as
-
-switch ($value) {
-  case $pattern: {
-    // access pattern variables
-  }
-  case _:
-}
-```
-
-```haxe
-while ($value is case $pattern) {
-  // access pattern variables
-}
-
-// same as
-
-while (true) {
-  switch ($value) {
-    case $pattern: {
-      // access pattern variables
-    }
-    case _: break;
-  }
-}
-```
-
-Usage:
-
-```haxe
-function ifSome(option: Option<Int>, then: (int: Int) -> Void): Void {
-  if (option is case Some(int)) {
-    then(int);
-  }
-}
-
-function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> Void): Void {
-  if (option is case Some(int).where(int % divisor == 0)) {
-    then(int);
-  }
-}
-```
-
-## Impact on existing code
-
-None.
-
-## Drawbacks
-
-None?
-
-## Alternatives
-
-Limited `EnumValue.match` or custom macro.
-
-## Unresolved questions
-
-None?
+`.match` can be kept as an alias which is limited to enum values or depreciated.

--- a/proposals/0000-single-pattern-checks.md
+++ b/proposals/0000-single-pattern-checks.md
@@ -11,55 +11,82 @@ New syntax for single pattern checks.
 
 Current single pattern check - `match` method on an enum value - is limited in functionality compared to usual pattern matching. No captures or guards and only a single enum value as a root value.
 
-Proposed syntax will allow to use full arsenal of matcher for two common scenarios.
+Proposed syntax will allow to use full arsenal of the matcher.
 
 ## Detailed design
 
-All of single pattern checks allias such switch:
-
-```haxe
-switch ($value) {
-  case $pattern if ($guard): $ifBody;
-  case _: $elseBody;
-}
-```
-
 ### Test a pattern
 
-```
-is case $value => $pattern [if ($guard)]
+Get a boolean result with:
+
+```haxe
+$value is case $pattern
+
+// same as
+
+switch ($value) {case $pattern: true; case _: false;}
 ```
 
-With `$ifBody` being `true` and `$elseBody` - `false`.
+Usage:
 
 ```haxe
 function isSome(option: Option<Int>): Bool {
-  return is case option => Some(_);
+  return option is case Some(_);
 }
 
 function isDivisibleSome(option: Option<Int>, divisor: Int): Bool {
-  return is case option => Some(int) if (int % divisor == 0);
+  return option is case Some(int).where(int % divisor == 0);
 }
 ```
 
-### Use a pattern as condition
+### Use captured variables in a conditional body
 
-```
-in case $value => $pattern [if ($guard)]: $ifBody [else $elseBody]
+If an `if` or `while` condition is a single `is case` expression, then it is transformed like this:
+
+```haxe
+if ($value is case $pattern) {
+  // access pattern variables
+}
+
+// same as
+
+switch ($value) {
+  case $pattern: {
+    // access pattern variables
+  }
+  case _:
+}
 ```
 
 ```haxe
+while ($value is case $pattern) {
+  // access pattern variables
+}
+
+// same as
+
+while (true) {
+  switch ($value) {
+    case $pattern: {
+      // access pattern variables
+    }
+    case _: break;
+  }
+}
+```
+
+Usage:
+
+```haxe
 function ifSome(option: Option<Int>, then: (int: Int) -> Void): Void {
-  in case option => Some(int): {
+  if (option is case Some(int)) {
     then(int);
   }
 }
 
-function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> Void, or: () -> Void): Void {
-  in case option => Some(int) if (int % divisor == 0): {
+function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> Void): Void {
+  if (option is case Some(int).where(int % divisor == 0)) {
     then(int);
-  } else {
-    or();
   }
 }
 ```
@@ -74,7 +101,7 @@ None?
 
 ## Alternatives
 
-`EnumValue.match` or custom macro.
+Limited `EnumValue.match` or custom macro.
 
 ## Unresolved questions
 

--- a/proposals/0000-single-pattern-checks.md
+++ b/proposals/0000-single-pattern-checks.md
@@ -67,24 +67,26 @@ function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> 
 ### Extract pattern variables with `extract match`
 
 ```
-$value extract match $pattern [where $guard] [else $elseBody]
+[$vars =] $value extract match $pattern [where $guard] [else $elseBody]
 ```
 
-With `$elseBody` throwing an exception by default and `$ifBody` being everything that follows in a block.
+`$vars` acts as a whitelist for exposing pattern's captured variables.
+`$elseBody` throws an exception by default. 
+`$ifBody` being everything that follows in a block.
 
 ```haxe
 function getSome(option: Option<Int>): Int {
-  option extract match Some(int);
+  final int = option extract match Some(int);
   return int;
 }
 
 function getNullSome(option: Option<Int>): Null<Int> {
-  option extract match Some(int) else return null;
+  final int = option extract match Some(int) else return null;
   return int;
 }
 
 function getDivisibleSome(option: Option<Int>, divisor: Int): Int {
-  option extract match Some(int) where (int % divisor == 0);
+  final int = option extract match Some(int) where (int % divisor == 0);
   return int;
 }
 ```

--- a/proposals/0000-single-pattern-checks.md
+++ b/proposals/0000-single-pattern-checks.md
@@ -1,0 +1,106 @@
+# Single pattern checks
+
+* Proposal: [HXP-NNNN](NNNN-single-pattern-checks.md)
+* Author: [Dmitrii Maganov](https://github.com/vonagam)
+
+## Introduction
+
+New syntax for single pattern checks.
+
+## Motivation
+
+Current single pattern check - `match` method on an enum value - is limited in functionality compared to usual pattern matching. No captures or guards and only a single enum value as a root value.
+
+Proposed syntax will allow to use full arsenal of matcher for three common scenarios.
+
+## Detailed design
+
+All of single pattern checks allias such switch:
+
+```haxe
+switch ($value) {
+  case $pattern if ($guard): $ifBody;
+  case _: $elseBody;
+}
+```
+
+### Pattern test with `is case`
+
+```
+$value is case $pattern [where ($guard)]
+```
+
+With `$ifBody` being `true` and `$elseBody` - `false`.
+
+```haxe
+function isSome(option: Option<Int>): Bool {
+  return option is case Some(_);
+}
+
+function isDivisibleSome(option: Option<Int>, divisor: Int): Bool {
+  return option is case Some(int) where (int % divisor == 0);
+}
+```
+
+### Pattern condition with `if case`
+
+```
+if case ($value, $pattern[, $guard]) $ifBody [else $elseBody]
+```
+
+```haxe
+function ifSome(option: Option<Int>, then: (int: Int) -> Void): Void {
+  if case (option, Some(int)) {
+    then(int);
+  }
+}
+
+function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> Void, or: () -> Void): Void {
+  if case (option, Some(int), int % divisor == 0) {
+    then(int);
+  } else {
+    or();
+  }
+}
+```
+
+### Pattern assertion with `cast case`
+
+```
+$value cast case $pattern [where ($guard)] [else $elseBody]
+```
+
+With `$elseBody` throwing an exception by default and `$ifBody` being everything that follows in a block.
+
+```haxe
+function getSome(option: Option<Int>): Int {
+  option cast case Some(int);
+  return int;
+}
+
+function getNullSome(option: Option<Int>): Null<Int> {
+  option cast case Some(int) else return null;
+  return int;
+}
+
+function getDivisibleSome(option: Option<Int>, divisor: Int): Int {
+  option cast case Some(int) where (int % divisor == 0);
+  return int;
+}
+```
+
+## Impact on existing code
+
+None.
+
+## Drawbacks
+
+None?
+
+## Alternatives
+
+`EnumValue.match` or custom macro.
+
+## Unresolved questions
+
+None?

--- a/proposals/0000-single-pattern-checks.md
+++ b/proposals/0000-single-pattern-checks.md
@@ -64,29 +64,29 @@ function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> 
 }
 ```
 
-### Extract pattern variables with `extract match`
+### Capture pattern variables with `capture match`
 
 ```
-$value extract match $pattern [where $guard] [else $elseBody]
+$value capture match $pattern [where $guard] [else $elseBody]
 ```
 
-`$elseBody` throws an exception by default and if provided must be `return`, `break`, `continue` or `throw`.
-`$ifBody` sets captured variables in current scope.
+`$ifBody` returns a structure with captured variables.
+`$elseBody` throws an exception by default.
 
 ```haxe
 function getSome(option: Option<Int>): Int {
-  option extract match Some(int);
-  return int;
+  var some = option capture match Some(int);
+  return some.int;
 }
 
 function getNullSome(option: Option<Int>): Null<Int> {
-  option extract match Some(int) else return null;
-  return int;
+  var some = option capture match Some(int) else {int: null};
+  return some.int;
 }
 
 function getDivisibleSome(option: Option<Int>, divisor: Int): Int {
-  option extract match Some(int) where (int % divisor == 0);
-  return int;
+  var some = option capture match Some(int) where (int % divisor == 0);
+  return some.int;
 }
 ```
 

--- a/proposals/0000-single-pattern-checks.md
+++ b/proposals/0000-single-pattern-checks.md
@@ -27,36 +27,36 @@ switch ($value) {
 ### Test a pattern
 
 ```
-case($value, $pattern[, $guard])
+is case $value => $pattern [if ($guard)]
 ```
 
 With `$ifBody` being `true` and `$elseBody` - `false`.
 
 ```haxe
 function isSome(option: Option<Int>): Bool {
-  return case(option, Some(_));
+  return is case option => Some(_);
 }
 
 function isDivisibleSome(option: Option<Int>, divisor: Int): Bool {
-  return case(option, Some(int), int % divisor == 0);
+  return is case option => Some(int) if (int % divisor == 0);
 }
 ```
 
 ### Use a pattern as condition
 
 ```
-if case($value, $pattern[, $guard]) $ifBody [else $elseBody]
+in case $value => $pattern [if ($guard)]: $ifBody [else $elseBody]
 ```
 
 ```haxe
 function ifSome(option: Option<Int>, then: (int: Int) -> Void): Void {
-  if case(option, Some(int)) {
+  in case option => Some(int): {
     then(int);
   }
 }
 
 function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> Void, or: () -> Void): Void {
-  if case(option, Some(int), int % divisor == 0) {
+  in case option => Some(int) if (int % divisor == 0): {
     then(int);
   } else {
     or();

--- a/proposals/0000-single-pattern-checks.md
+++ b/proposals/0000-single-pattern-checks.md
@@ -24,39 +24,39 @@ switch ($value) {
 }
 ```
 
-### Test a pattern with `is match`
+### Test a pattern with `case is`
 
 ```
-$value is match $pattern [where $guard]
+$value case is $pattern [if ($guard)]
 ```
 
 With `$ifBody` being `true` and `$elseBody` - `false`.
 
 ```haxe
 function isSome(option: Option<Int>): Bool {
-  return option is match Some(_);
+  return option case is Some(_);
 }
 
 function isDivisibleSome(option: Option<Int>, divisor: Int): Bool {
-  return option is match Some(int) where (int % divisor == 0);
+  return option case is Some(int) if (int % divisor == 0);
 }
 ```
 
-### Use a pattern as condition with `if match`
+### Use a pattern as condition with `case`
 
 ```
-if $value match $pattern [where $guard] $ifBody [else $elseBody]
+$value case $pattern [if ($guard)]: $ifBody [else $elseBody]
 ```
 
 ```haxe
 function ifSome(option: Option<Int>, then: (int: Int) -> Void): Void {
-  if option match Some(int) {
+  option case Some(int): {
     then(int);
   }
 }
 
 function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> Void, or: () -> Void): Void {
-  if option match Some(int) where (int % divisor == 0) {
+  option case Some(int) if (int % divisor == 0): {
     then(int);
   } else {
     or();
@@ -64,28 +64,28 @@ function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> 
 }
 ```
 
-### Capture pattern variables with `capture match`
+### Get pattern variables with `case vars`
 
 ```
-$value capture match $pattern [where $guard] [else $elseBody]
+$value case vars $pattern [if ($guard)] [else $elseBody]
 ```
 
-`$ifBody` returns a structure with captured variables.
+`$ifBody` returns a structure with captured variables. 
 `$elseBody` throws an exception by default.
 
 ```haxe
 function getSome(option: Option<Int>): Int {
-  var some = option capture match Some(int);
+  var some = option case vars Some(int);
   return some.int;
 }
 
 function getNullSome(option: Option<Int>): Null<Int> {
-  var some = option capture match Some(int) else {int: null};
+  var some = option case vars Some(int) else {int: null};
   return some.int;
 }
 
 function getDivisibleSome(option: Option<Int>, divisor: Int): Int {
-  var some = option capture match Some(int) where (int % divisor == 0);
+  var some = option case vars Some(int) if (int % divisor == 0);
   return some.int;
 }
 ```

--- a/proposals/0000-single-pattern-checks.md
+++ b/proposals/0000-single-pattern-checks.md
@@ -24,39 +24,39 @@ switch ($value) {
 }
 ```
 
-### Pattern test with `is case`
+### Test a pattern with `is match`
 
 ```
-$value is case $pattern [where ($guard)]
+$value is match $pattern [where $guard]
 ```
 
 With `$ifBody` being `true` and `$elseBody` - `false`.
 
 ```haxe
 function isSome(option: Option<Int>): Bool {
-  return option is case Some(_);
+  return option is match Some(_);
 }
 
 function isDivisibleSome(option: Option<Int>, divisor: Int): Bool {
-  return option is case Some(int) where (int % divisor == 0);
+  return option is match Some(int) where (int % divisor == 0);
 }
 ```
 
-### Pattern condition with `if case`
+### Use a pattern as condition with `if match`
 
 ```
-if case ($value, $pattern[, $guard]) $ifBody [else $elseBody]
+if $value match $pattern [where $guard] $ifBody [else $elseBody]
 ```
 
 ```haxe
 function ifSome(option: Option<Int>, then: (int: Int) -> Void): Void {
-  if case (option, Some(int)) {
+  if option match Some(int) {
     then(int);
   }
 }
 
 function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> Void, or: () -> Void): Void {
-  if case (option, Some(int), int % divisor == 0) {
+  if option match Some(int) where (int % divisor == 0) {
     then(int);
   } else {
     or();
@@ -64,27 +64,27 @@ function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> 
 }
 ```
 
-### Pattern assertion with `cast case`
+### Extract pattern variables with `extract match`
 
 ```
-$value cast case $pattern [where ($guard)] [else $elseBody]
+$value extract match $pattern [where $guard] [else $elseBody]
 ```
 
 With `$elseBody` throwing an exception by default and `$ifBody` being everything that follows in a block.
 
 ```haxe
 function getSome(option: Option<Int>): Int {
-  option cast case Some(int);
+  option extract match Some(int);
   return int;
 }
 
 function getNullSome(option: Option<Int>): Null<Int> {
-  option cast case Some(int) else return null;
+  option extract match Some(int) else return null;
   return int;
 }
 
 function getDivisibleSome(option: Option<Int>, divisor: Int): Int {
-  option cast case Some(int) where (int % divisor == 0);
+  option extract match Some(int) where (int % divisor == 0);
   return int;
 }
 ```

--- a/proposals/0000-single-pattern-checks.md
+++ b/proposals/0000-single-pattern-checks.md
@@ -11,7 +11,7 @@ New syntax for single pattern checks.
 
 Current single pattern check - `match` method on an enum value - is limited in functionality compared to usual pattern matching. No captures or guards and only a single enum value as a root value.
 
-Proposed syntax will allow to use full arsenal of matcher for three common scenarios.
+Proposed syntax will allow to use full arsenal of matcher for two common scenarios.
 
 ## Detailed design
 
@@ -24,69 +24,43 @@ switch ($value) {
 }
 ```
 
-### Test a pattern with `case is`
+### Test a pattern
 
 ```
-$value case is $pattern [if ($guard)]
+case($value, $pattern[, $guard])
 ```
 
 With `$ifBody` being `true` and `$elseBody` - `false`.
 
 ```haxe
 function isSome(option: Option<Int>): Bool {
-  return option case is Some(_);
+  return case(option, Some(_));
 }
 
 function isDivisibleSome(option: Option<Int>, divisor: Int): Bool {
-  return option case is Some(int) if (int % divisor == 0);
+  return case(option, Some(int), int % divisor == 0);
 }
 ```
 
-### Use a pattern as condition with `case`
+### Use a pattern as condition
 
 ```
-$value case $pattern [if ($guard)]: $ifBody [else $elseBody]
+if case($value, $pattern[, $guard]) $ifBody [else $elseBody]
 ```
 
 ```haxe
 function ifSome(option: Option<Int>, then: (int: Int) -> Void): Void {
-  option case Some(int): {
+  if case(option, Some(int)) {
     then(int);
   }
 }
 
 function ifDivisibleSome(option: Option<Int>, divisor: Int, then: (int: Int) -> Void, or: () -> Void): Void {
-  option case Some(int) if (int % divisor == 0): {
+  if case(option, Some(int), int % divisor == 0) {
     then(int);
   } else {
     or();
   }
-}
-```
-
-### Get pattern variables with `case vars`
-
-```
-$value case vars $pattern [if ($guard)] [else $elseBody]
-```
-
-`$ifBody` returns a structure with captured variables. 
-`$elseBody` throws an exception by default.
-
-```haxe
-function getSome(option: Option<Int>): Int {
-  var some = option case vars Some(int);
-  return some.int;
-}
-
-function getNullSome(option: Option<Int>): Null<Int> {
-  var some = option case vars Some(int) else {int: null};
-  return some.int;
-}
-
-function getDivisibleSome(option: Option<Int>, divisor: Int): Int {
-  var some = option case vars Some(int) if (int % divisor == 0);
-  return some.int;
 }
 ```
 


### PR DESCRIPTION
Proposal to rename `.match` method for single pattern checks to `.case` for it to work on any type, not only on enums.
```haxe
value.case(pattern) // returns a boolean
```

[Render.](https://github.com/vonagam/haxe-evolution/blob/single-pattern-checks/proposals/0000-single-pattern-checks.md)