### PR TITLE
Caller tracking.

### DIFF
--- a/proposals/0000-track-caller.md
+++ b/proposals/0000-track-caller.md
@@ -27,11 +27,11 @@ function foo(caller:haxe.PosInfos) {
 	trace(caller);
 }
 
-foo(haxe.Magic.currentLocation());
+foo($currentLocation);
 ```
-When rest arguments are involved, the exact implementation depends on how rest arguments are implemented.
+When rest arguments are involved, the exact implementation may be different (possibly depending on how they are implemented on the target).
 
-`var closureOfTrackCallerFun = foo` turns into `var closureOfTrackCallerFun = foo.bind(haxe.Magic.currentLocation())`.
+`var closureOfTrackCallerFun = foo` turns into `var closureOfTrackCallerFun = foo.bind($currentLocation)`.
 
 `haxe.Magic.callerLocation()` returns the position of the last call of a `@:trackCaller` function in a non-trackcaller functions.
 

--- a/proposals/0000-track-caller.md
+++ b/proposals/0000-track-caller.md
@@ -81,6 +81,9 @@ Would break in the case `(@:callerLocation pos:haxe.PosInfos = cast null, ...res
 
 ## Opening possibilities
 
+Turn `trace` into `@:trackCaller function trace(...args:Dynamic)`.
+Then the only magic left would be auto-importing it everywhere.
+
 ## Unresolved questions
 
 `haxe.Magic` is a bit too magic. Where should the `callerLocation` function live?

--- a/proposals/0000-track-caller.md
+++ b/proposals/0000-track-caller.md
@@ -73,6 +73,15 @@ None.
 
 The magic `?pos:haxe.PosInfos` argument could be made even more magic by being allowed after Rest arguments.
 
+Walking up the stack in `callLocation` is also a possibility, but would break when inlining is involved.
+It also requires generation of some kind of debug info.
+
+Make the compiler allow `callLocation` in default arguments eg `pos:haxe.PosInfos = callLocation()`.
+Would break in the case `(pos:haxe.PosInfos = callLocation(), ...rest:haxe.PosInfos)`.
+
+Make `@:callerLocation` meta on default argument eg `@:callerLocation pos:haxe.PosInfos = cast null`.
+Would break in the case `(@:callerLocation pos:haxe.PosInfos = cast null, ...rest:haxe.PosInfos)` unless magic semantics are given to the default argument when annoated with `@:callerLocation`.
+
 ## Opening possibilities
 
 ## Unresolved questions

--- a/proposals/0000-track-caller.md
+++ b/proposals/0000-track-caller.md
@@ -1,0 +1,80 @@
+# Caller tracking.
+
+* Proposal: [HXP-NNNN](NNNN-filename.md)
+* Author: [Zeta](https://github.com/Apprentice-Alchemist)
+
+## Introduction
+
+`@:trackCaller` metadata + `haxe.Magic.callLocation()` as a replacement for `?pos:haxe.PosInfos`.
+
+## Motivation
+
+The magic `?pos:haxe.PosInfos` argument does not work with rest arguments.
+
+## Detailed design
+
+```hx
+@:trackCaller
+function foo() {
+	trace(haxe.Magic.callLocation());
+}
+
+foo();
+
+// turns into
+
+function foo(caller:haxe.PosInfos) {
+	trace(caller);
+}
+
+foo(haxe.Magic.currentLocation());
+```
+When rest arguments are involved, the exact implementation depends on how rest arguments are implemented.
+
+When `@:trackCaller` is applied to interface methods, abstract methods or methods that will be overriden,
+the implementors/overriders inherit the attribute.
+
+`var closureOfTrackCallerFun = foo` turns into `var closureOfTrackCallerFun = foo.bind(haxe.Magic.currentLocation())`.
+
+`haxe.Magic.callLocation()` returns the position of the last call of a `@:trackCaller` function in a non-trackcaller functions.
+
+For example:
+```hx
+@:trackCaller
+function bar() {
+	foo();
+}
+
+@:trackCaller
+function foo() {
+	trace(haxe.Magic.callLocation());
+}
+
+// turns into
+
+function bar(caller: haxe.PosInfos) {
+	foo(caller);
+}
+
+function foo(caller:haxe.PosInfos) {
+	trace(caller);
+}
+```
+
+## Impact on existing code
+
+None.
+
+## Drawbacks
+
+None.
+
+## Alternatives
+
+The magic `?pos:haxe.PosInfos` argument could be made even more magic by being allowed after Rest arguments.
+
+## Opening possibilities
+
+## Unresolved questions
+
+Where to put the `callLocation` function.

--- a/proposals/0000-track-caller.md
+++ b/proposals/0000-track-caller.md
@@ -34,6 +34,7 @@ When rest arguments are involved, the exact implementation may be different (pos
 `var closureOfTrackCallerFun = foo` turns into `var closureOfTrackCallerFun = foo.bind($currentLocation)`.
 
 `haxe.Magic.callerLocation()` returns the position of the last call of a `@:trackCaller` function in a non-trackcaller functions.
+This behaviour could be then be turned off by using `@:trackCaller(noPropagate)`.
 
 For example:
 ```hx
@@ -81,7 +82,7 @@ Would break in the case `(@:callerLocation pos:haxe.PosInfos = cast null, ...res
 
 ## Opening possibilities
 
-Turn `trace` into `@:trackCaller function trace(...args:Dynamic)`.
+Turn `trace` into `@:trackCaller(noPropagate) function trace(...args:Dynamic)`.
 Then the only magic left would be auto-importing it everywhere.
 
 ## Unresolved questions

--- a/proposals/0000-track-caller.md
+++ b/proposals/0000-track-caller.md
@@ -31,9 +31,6 @@ foo(haxe.Magic.currentLocation());
 ```
 When rest arguments are involved, the exact implementation depends on how rest arguments are implemented.
 
-When `@:trackCaller` is applied to interface methods, abstract methods or methods that will be overriden,
-the implementors/overriders inherit the attribute.
-
 `var closureOfTrackCallerFun = foo` turns into `var closureOfTrackCallerFun = foo.bind(haxe.Magic.currentLocation())`.
 
 `haxe.Magic.callLocation()` returns the position of the last call of a `@:trackCaller` function in a non-trackcaller functions.
@@ -87,3 +84,5 @@ Would break in the case `(@:callerLocation pos:haxe.PosInfos = cast null, ...res
 ## Unresolved questions
 
 Where to put the `callLocation` function.
+
+How this would work with interfaces and abstract/overriden methods.

--- a/proposals/0000-track-caller.md
+++ b/proposals/0000-track-caller.md
@@ -5,7 +5,7 @@
 
 ## Introduction
 
-`@:trackCaller` metadata + `haxe.Magic.callLocation()` as a replacement for `?pos:haxe.PosInfos`.
+`@:trackCaller` metadata + `haxe.Magic.callerLocation()` as a replacement for `?pos:haxe.PosInfos`.
 
 ## Motivation
 
@@ -16,7 +16,7 @@ The magic `?pos:haxe.PosInfos` argument does not work with rest arguments.
 ```hx
 @:trackCaller
 function foo() {
-	trace(haxe.Magic.callLocation());
+	trace(haxe.Magic.callerLocation());
 }
 
 foo();
@@ -33,7 +33,7 @@ When rest arguments are involved, the exact implementation depends on how rest a
 
 `var closureOfTrackCallerFun = foo` turns into `var closureOfTrackCallerFun = foo.bind(haxe.Magic.currentLocation())`.
 
-`haxe.Magic.callLocation()` returns the position of the last call of a `@:trackCaller` function in a non-trackcaller functions.
+`haxe.Magic.callerLocation()` returns the position of the last call of a `@:trackCaller` function in a non-trackcaller functions.
 
 For example:
 ```hx
@@ -44,7 +44,7 @@ function bar() {
 
 @:trackCaller
 function foo() {
-	trace(haxe.Magic.callLocation());
+	trace(haxe.Magic.callerLocation());
 }
 
 // turns into
@@ -70,11 +70,11 @@ None.
 
 The magic `?pos:haxe.PosInfos` argument could be made even more magic by being allowed after Rest arguments.
 
-Walking up the stack in `callLocation` is also a possibility, but would break when inlining is involved.
+Walking up the stack in `callerLocation` is also a possibility, but would break when inlining is involved.
 It also requires generation of some kind of debug info.
 
-Make the compiler allow `callLocation` in default arguments eg `pos:haxe.PosInfos = callLocation()`.
-Would break in the case `(pos:haxe.PosInfos = callLocation(), ...rest:haxe.PosInfos)`.
+Make the compiler allow `callerLocation` in default arguments eg `pos:haxe.PosInfos = callerLocation()`.
+Would break in the case `(pos:haxe.PosInfos = callerLocation(), ...rest:haxe.PosInfos)`.
 
 Make `@:callerLocation` meta on default argument eg `@:callerLocation pos:haxe.PosInfos = cast null`.
 Would break in the case `(@:callerLocation pos:haxe.PosInfos = cast null, ...rest:haxe.PosInfos)` unless magic semantics are given to the default argument when annotated with `@:callerLocation`.
@@ -83,6 +83,6 @@ Would break in the case `(@:callerLocation pos:haxe.PosInfos = cast null, ...res
 
 ## Unresolved questions
 
-Where to put the `callLocation` function.
+`haxe.Magic` is a bit too magic. Where should the `callerLocation` function live?
 
 How this would work with interfaces and abstract/overriden methods.

--- a/proposals/0000-track-caller.md
+++ b/proposals/0000-track-caller.md
@@ -77,7 +77,7 @@ Make the compiler allow `callLocation` in default arguments eg `pos:haxe.PosInfo
 Would break in the case `(pos:haxe.PosInfos = callLocation(), ...rest:haxe.PosInfos)`.
 
 Make `@:callerLocation` meta on default argument eg `@:callerLocation pos:haxe.PosInfos = cast null`.
-Would break in the case `(@:callerLocation pos:haxe.PosInfos = cast null, ...rest:haxe.PosInfos)` unless magic semantics are given to the default argument when annoated with `@:callerLocation`.
+Would break in the case `(@:callerLocation pos:haxe.PosInfos = cast null, ...rest:haxe.PosInfos)` unless magic semantics are given to the default argument when annotated with `@:callerLocation`.
 
 ## Opening possibilities
 

--- a/proposals/0000-track-caller.md
+++ b/proposals/0000-track-caller.md
@@ -90,3 +90,5 @@ Then the only magic left would be auto-importing it everywhere.
 `haxe.Magic` is a bit too magic. Where should the `callerLocation` function live? A module-level function in `haxe.PosInfos`?
 
 How this would work with interfaces and abstract/overriden methods.
+
+Is `noPropagate` the best name to disable propagation? Maybe `@:trackCaller(ignorePropagation)` is better? 

--- a/proposals/0000-track-caller.md
+++ b/proposals/0000-track-caller.md
@@ -87,6 +87,6 @@ Then the only magic left would be auto-importing it everywhere.
 
 ## Unresolved questions
 
-`haxe.Magic` is a bit too magic. Where should the `callerLocation` function live?
+`haxe.Magic` is a bit too magic. Where should the `callerLocation` function live? A module-level function in `haxe.PosInfos`?
 
 How this would work with interfaces and abstract/overriden methods.


### PR DESCRIPTION
A replacement for that `?pos:haxe.PosInfos` magic.

[Rendered proposal](https://github.com/Apprentice-Alchemist/haxe-evolution/blob/proposal/track-caller/proposals/0000-track-caller.md)